### PR TITLE
fix error on processing empty string

### DIFF
--- a/krnnt/new.py
+++ b/krnnt/new.py
@@ -659,6 +659,9 @@ def batch_generator(generator, batch_size=32, return_all=False, sort=False):
 
 def pad_generator(generator,sequence_length=20):
     for batch_X,batch_y, sentences,sentences_orig in generator:
+        if not batch_X or not batch_y:
+            continue
+
         #TODO pad multi inputs
         max_sentence_length = max([len(x) for x in batch_X])
         # print('max_sentence_length',max_sentence_length)
@@ -666,6 +669,9 @@ def pad_generator(generator,sequence_length=20):
 
 def pad_generatorE(generator,sequence_length=20):
     for batch_X,batch_y, sentences,sentences_orig,batch_X_e  in generator:
+        if not batch_X or not batch_y or not batch_X_e:
+            continue
+
         #TODO pad multi inputs
         max_sentence_length = max([len(x) for x in batch_X])
         # print('max_sentence_length',max_sentence_length)

--- a/krnnt/pipeline.py
+++ b/krnnt/pipeline.py
@@ -302,6 +302,9 @@ class Preprocess:
 
     @staticmethod
     def pad(batch, unique_features_dict, feature_name):
+        if not batch:
+            return []
+
         #feature_name='tags4e3'
         result_batchX = []
         # print('batch len',len(batch))
@@ -321,6 +324,9 @@ class Preprocess:
 
 
 def chunk(l, batch_size):
+    if not l:
+        return
+
     n=max(len(l)//batch_size,1)
     # print('n', n)
     k, m = divmod(len(l), n)


### PR DESCRIPTION
This commit fixes error occurring when processing empty string with krnnt_serve.py:

```
tagger_1  | Exception happened during processing of request from ('172.24.0.1', 45276)
tagger_1  | Traceback (most recent call last):
tagger_1  |   File "/usr/lib/python3.5/socketserver.py", line 313, in _handle_request_noblock
tagger_1  |     self.process_request(request, client_address)
tagger_1  |   File "/usr/lib/python3.5/socketserver.py", line 341, in process_request
tagger_1  |     self.finish_request(request, client_address)
tagger_1  |   File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
tagger_1  |     self.RequestHandlerClass(request, client_address, self)
tagger_1  |   File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
tagger_1  |     self.handle()
tagger_1  |   File "/usr/lib/python3.5/http/server.py", line 422, in handle
tagger_1  |     self.handle_one_request()
tagger_1  |   File "/usr/lib/python3.5/http/server.py", line 410, in handle_one_request
tagger_1  |     method()
tagger_1  |   File "/home/krnnt/krnnt/krnnt_serve.py", line 33, in do_POST
tagger_1  |     results = krnnt.tag_sentences(post_data.decode('utf-8').split('\n\n')) # ['Ala ma kota.', 'Ale nie ma psa.']
tagger_1  |   File "/home/krnnt/krnnt/krnnt/pipeline.py", line 41, in tag_sentences
tagger_1  |     return self.__tag(sentences, preana)
tagger_1  |   File "/home/krnnt/krnnt/krnnt/pipeline.py", line 51, in __tag
tagger_1  |     pad_batch=Preprocess.pad(batch, self.unique_features_dict, 'tags4e3')
tagger_1  |   File "/home/krnnt/krnnt/krnnt/pipeline.py", line 320, in pad
tagger_1  |     return sequence.pad_sequences(result_batchX) #, sequence.pad_sequences(result_batchY, maxlen=max_sentence_length)
tagger_1  |   File "/usr/local/lib/python3.5/dist-packages/keras/preprocessing/sequence.py", line 64, in pad_sequences
tagger_1  |     maxlen = np.max(lengths)
tagger_1  |   File "/usr/local/lib/python3.5/dist-packages/numpy/core/fromnumeric.py", line 2320, in amax
tagger_1  |     out=out, **kwargs)
tagger_1  |   File "/usr/local/lib/python3.5/dist-packages/numpy/core/_methods.py", line 26, in _amax
tagger_1  |     return umr_maximum(a, axis, None, out, keepdims)
tagger_1  | ValueError: zero-size array to reduction operation maximum which has no identity
```

The problem is caused by calling keras.preprocessing.sequence.pad_sequences with empty list as sequences. Keras expects sequences to be lists of lists or at least iterble of lists. Pad_sequences does not check if given sequences are empty but proceed with execution. Then if maxlen is also not specified, it will just iterate over sequences and check maxlen itself:
```
    if maxlen is None:
        maxlen = np.max(lengths)
```
But since sequences is empty, so is lengths and calling np.max with empty seq results in mentioned error.

To fix this, it should be checked that pad_sequences is not called with empty sequence. Such checks are added in this pr. Also similar check is added in chunk generator in krnnt.pipeline.py which I assume should not yield anything on empty sequence (currently it will yield [] given [] as an input).
